### PR TITLE
[Feat] Challenges 테이블에 page 필드 추가(진도율 저장을 위함)

### DIFF
--- a/src/main/java/wandogis/wandogi/domain/Challenges.java
+++ b/src/main/java/wandogis/wandogi/domain/Challenges.java
@@ -20,21 +20,23 @@ public class Challenges {
     private String title;
     private String author;
     private String photo;
+    private int page;  // 진도율 저장을 위한 페이지 수
     private int view;
     private Date startDate;
     private Date endDate;
     private ArrayList<ObjectId> people;   // 챌린지 참여한 사람들 Users 배열
     private ArrayList<Double> progress;    // 진도율(people 배열과 동일한 index를 가진 값이 그 유저의 진도율)
-    private int success;    // 챌린지 성공 여부(0:실패, 1:성공, 2:진행중)
+    private Boolean success;    // 챌린지 성공 여부(실패: False, 성공: True)
 
     @Builder
-    public Challenges(ObjectId id, String isbn, String title, String author, String photo,
-                      int view, Date startDate, Date endDate, ArrayList<ObjectId> people, ArrayList<Double> progress, int success) {
+    public Challenges(ObjectId id, String isbn, String title, String author, String photo, int page,
+                      int view, Date startDate, Date endDate, ArrayList<ObjectId> people, ArrayList<Double> progress, Boolean success) {
         this.id = id;
         this.isbn = isbn;
         this.title = title;
         this.author = author;
         this.photo = photo;
+        this.page = page;
         this.view = view;
         this.startDate = startDate;
         this.endDate = endDate;


### PR DESCRIPTION
challenged 테이블에 page수를 저장하는 page 필드를 추가했습니다.
유저가 읽은 페이지 수를 입력할 때 진도율을 계산해서 표시하려면 해당 챌린지 책의 페이지 수가 필요하다는 것을 잊고 있었습니다..