### PR TITLE
[Feat] 알라딘 API를 사용한 도서 검색

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 	testImplementation 'junit:junit:4.13.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/wandogis/wandogi/controller/SearchBookController.java
+++ b/src/main/java/wandogis/wandogi/controller/SearchBookController.java
@@ -1,0 +1,24 @@
+package wandogis.wandogi.controller;
+
+import lombok.AllArgsConstructor;
+import org.json.simple.parser.ParseException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import wandogis.wandogi.service.SearchBookService;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("search")
+public class SearchBookController {
+    private SearchBookService searchBookService;
+
+    /**
+     * 도서 검색 - 알라딘 API 이용
+     */
+    @GetMapping("/book")
+    public Object getBookListAladin(@RequestParam String query) throws ParseException {
+        return searchBookService.getBookListFromAladinAPI(query);
+    }
+}

--- a/src/main/java/wandogis/wandogi/service/SearchBookService.java
+++ b/src/main/java/wandogis/wandogi/service/SearchBookService.java
@@ -1,0 +1,58 @@
+package wandogis.wandogi.service;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class SearchBookService {
+    /**
+     * 도서 검색
+     * @param query 검색어
+     * @return isbn13, title, cover 포함한 json
+     * isbn13이 존재하지 않는 경우, isbn을 보냄. isbn은 10자리
+     */
+    public JSONObject getBookListFromAladinAPI(String query) throws ParseException {
+        JSONObject result = new JSONObject();
+
+        String searchUrl = "https://www.aladin.co.kr/ttb/api/ItemSearch.aspx?QueryType=Title&start=1&SearchTarget=Book&output=js&Version=20131101&ttbkey=ttbkeum45151359001&";
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        HttpEntity<String> httpEntity = new HttpEntity<>(httpHeaders);
+        URI targetUrl = URI.create(UriComponentsBuilder
+                .fromUriString(searchUrl)
+                .queryParam("Query", query)
+                .encode(StandardCharsets.UTF_8)
+                .toUriString());
+        JSONObject list = restTemplate.exchange(targetUrl, HttpMethod.GET, httpEntity, JSONObject.class).getBody();
+
+        JSONParser parser = new JSONParser();
+        JSONObject object = (JSONObject) parser.parse(list.toString());
+        JSONArray items = (JSONArray) object.get("item");
+
+        JSONArray item = new JSONArray();
+        for (int i = 0; i < items.size(); i++) {
+            JSONObject obj = (JSONObject) items.get(i);
+            String isbn = (String) obj.get("isbn13");
+            if (isbn.length() < 13) isbn = (String) obj.get("isbn");
+            JSONObject data = new JSONObject();
+            data.put("isbn", isbn);
+            data.put("title", (String) obj.get("title"));
+            data.put("img", (String) obj.get("cover"));
+            item.add(data);
+        }
+        result.put("item", item);
+        return result;
+    }
+}

--- a/src/test/java/wandogis/wandogi/AladinAPITest.java
+++ b/src/test/java/wandogis/wandogi/AladinAPITest.java
@@ -1,0 +1,20 @@
+package wandogis.wandogi;
+
+import org.json.simple.JSONObject;
+import org.json.simple.parser.ParseException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import wandogis.wandogi.service.SearchBookService;
+
+@SpringBootTest()
+public class AladinAPITest {
+    @Autowired
+    private SearchBookService searchBookService;
+
+    @Test
+    public void getBookListAladin() throws ParseException {
+        JSONObject result = searchBookService.getBookListFromAladinAPI("삼국지");
+        System.out.println(result.toJSONString());
+    }
+}


### PR DESCRIPTION
도서 검색할 때 알라딘 API를 이용해서
isbn, title, cover(이미지) 보내주는 api 작성했습니다.
<img width="847" alt="스크린샷 2023-06-02 오전 12 51 03" src="https://github.com/Wandogis/Backend/assets/61774034/4261186e-a052-4ded-bc02-98de1ebc7fcc">

페이징 기능은 아직 없습니다.