### PR TITLE
[Feat] 도서 상세 페이지 - 도서 상세 정보 API

### DIFF
--- a/src/main/java/wandogis/wandogi/controller/DetailBookController.java
+++ b/src/main/java/wandogis/wandogi/controller/DetailBookController.java
@@ -1,0 +1,24 @@
+package wandogis.wandogi.controller;
+
+import lombok.AllArgsConstructor;
+import org.json.simple.parser.ParseException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import wandogis.wandogi.service.DetailBookService;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("detail")
+public class DetailBookController {
+    private DetailBookService detailBookService;
+
+    /**
+     * 도서 상세 페이지 - 알라딘 API 이용
+     */
+    @GetMapping("")
+    public Object getBookDetailInfo(@RequestParam String isbn) throws ParseException {
+        return detailBookService.getBookDetailInfoFromAladin(isbn);
+    }
+}

--- a/src/main/java/wandogis/wandogi/service/DetailBookService.java
+++ b/src/main/java/wandogis/wandogi/service/DetailBookService.java
@@ -1,0 +1,60 @@
+package wandogis.wandogi.service;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Service
+public class DetailBookService {
+    /**
+     * 도서 상세 정보
+     * @param isbn isbn
+     * @return isbn, title, cover, author, publisher, pubDate, description, itemPage 포함된 json
+     */
+    public JSONObject getBookDetailInfoFromAladin(String isbn) throws ParseException {
+        JSONObject result = new JSONObject();
+
+        String detailUrl = "https://www.aladin.co.kr/ttb/api/ItemLookUp.aspx?ttbkey=ttbkeum45151359001&output=js&Version=20131101&";
+
+        String isbnType;    // isbn이 13자리일 경우와 10자리일 경우 나눠야 함
+        if (isbn.length() < 13) isbnType = "ISBN";
+        else isbnType = "ISBN13";
+
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders httpHeaders = new HttpHeaders();
+        HttpEntity<String> httpEntity = new HttpEntity<>(httpHeaders);
+        URI targetUrl = URI.create(UriComponentsBuilder
+                .fromUriString(detailUrl)
+                .queryParam("ItemId", isbn)
+                .queryParam("itemIdType", isbnType)
+                .encode(StandardCharsets.UTF_8)
+                .toUriString());
+        JSONObject list = restTemplate.exchange(targetUrl, HttpMethod.GET, httpEntity, JSONObject.class).getBody();
+
+        JSONParser parser = new JSONParser();
+        JSONObject object = (JSONObject) parser.parse(list.toString());
+        JSONArray items = (JSONArray) object.get("item");
+        JSONObject data = (JSONObject) items.get(0);
+
+        result.put("isbn", isbn);
+        result.put("title", data.get("title"));
+        result.put("img", data.get("cover"));
+        result.put("author", data.get("author"));
+        result.put("description", data.get("description"));
+        result.put("pubDate", data.get("pubDate"));
+        result.put("publisher", data.get("publisher"));
+        JSONObject subInfo = (JSONObject) data.get("subInfo");
+        result.put("page", subInfo.get("itemPage"));
+        return result;
+    }
+}

--- a/src/test/java/wandogis/wandogi/AladinAPITest.java
+++ b/src/test/java/wandogis/wandogi/AladinAPITest.java
@@ -5,6 +5,7 @@ import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import wandogis.wandogi.service.DetailBookService;
 import wandogis.wandogi.service.SearchBookService;
 
 @SpringBootTest()
@@ -12,9 +13,18 @@ public class AladinAPITest {
     @Autowired
     private SearchBookService searchBookService;
 
+    @Autowired
+    private DetailBookService detailBookService;
+
     @Test
     public void getBookListAladin() throws ParseException {
         JSONObject result = searchBookService.getBookListFromAladinAPI("삼국지");
+        System.out.println(result.toJSONString());
+    }
+
+    @Test
+    public void getBookDetailAladin() throws ParseException {
+        JSONObject result = detailBookService.getBookDetailInfoFromAladin("9791190669030");
         System.out.println(result.toJSONString());
     }
 }


### PR DESCRIPTION
도서 상세 페이지에서 도서의 상세 정보를 보내주는 API를 작성했습니다.
보내주는 정보는 isbn, title, cover, author, pubDate, publisher, description, itemPage입니다.

<img width="855" alt="스크린샷 2023-06-03 오후 5 08 13" src="https://github.com/Wandogis/Backend/assets/61774034/d3ea36c5-040e-4438-bc36-0368b540ee2e">
