### PR TITLE
[Feat] 챌린지 생성 - 참여 유저와 진도율은 아직 저장 안 됨

### DIFF
--- a/src/main/java/wandogis/wandogi/controller/ChallengeController.java
+++ b/src/main/java/wandogis/wandogi/controller/ChallengeController.java
@@ -1,11 +1,10 @@
 package wandogis.wandogi.controller;
 
 import lombok.AllArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.json.simple.parser.ParseException;
+import org.springframework.web.bind.annotation.*;
 import wandogis.wandogi.domain.Challenges;
+import wandogis.wandogi.dto.ChallengeCreateDto;
 import wandogis.wandogi.service.ChallengeService;
 
 import java.util.List;
@@ -64,5 +63,13 @@ public class ChallengeController {
         List<Challenges> isbnList = challengeService.getChallengeListByIsbnAndDate(isbn);
         List<Challenges> isbnLatestList = challengeService.getChallengeListByDate(isbnList);
         return isbnLatestList;
+    }
+
+    /**
+     * 챌린지 생성
+     */
+    @PostMapping("/create")
+    public void createChallenge(@RequestParam String isbn, @RequestBody ChallengeCreateDto challengeCreateDto) throws ParseException {
+        challengeService.saveChallenge(challengeCreateDto, isbn);
     }
 }

--- a/src/main/java/wandogis/wandogi/domain/Challenges.java
+++ b/src/main/java/wandogis/wandogi/domain/Challenges.java
@@ -3,9 +3,11 @@ package wandogis.wandogi.domain;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import org.bson.types.ObjectId;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.Id;
-import org.springframework.format.annotation.DateTimeFormat;
 
+import javax.persistence.Column;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.Date;
@@ -22,30 +24,35 @@ public class Challenges {
     private String title;
     private String author;
     private String photo;
+    private String description;
+    private String category;
     private int page;  // 진도율 저장을 위한 페이지 수
+    @ColumnDefault("0")
     private int view;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date startDate;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date endDate;
-    private ArrayList<ObjectId> people;   // 챌린지 참여한 사람들 Users 배열
+    @OneToMany(mappedBy = "challenges")
+    private ArrayList<Users> people = new ArrayList<>();   // 챌린지 참여한 사람들 Users 배열
     private ArrayList<Double> progress;    // 진도율(people 배열과 동일한 index를 가진 값이 그 유저의 진도율)
+    @Column(nullable = true)
     private Boolean success;    // 챌린지 성공 여부(실패: False, 성공: True)
 
     @Builder
-    public Challenges(ObjectId id, String isbn, String title, String author, String photo, int page,
-                      int view, Date startDate, Date endDate, ArrayList<ObjectId> people, ArrayList<Double> progress, Boolean success) {
+    public Challenges(ObjectId id, String isbn, String title, String author, String photo, String description, String category, int page,
+                      int view, Date startDate, Date endDate, ArrayList<Users> people, ArrayList<Double> progress, Boolean success) {
         this.id = id;
         this.isbn = isbn;
         this.title = title;
         this.author = author;
         this.photo = photo;
+        this.description = description;
+        this.category = category;
         this.page = page;
         this.view = view;
         this.startDate = startDate;
         this.endDate = endDate;
-        this.people = people;
-        this.progress = progress;
         this.success = success;
     }
 }

--- a/src/main/java/wandogis/wandogi/dto/ChallengeCreateDto.java
+++ b/src/main/java/wandogis/wandogi/dto/ChallengeCreateDto.java
@@ -1,0 +1,38 @@
+package wandogis.wandogi.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import wandogis.wandogi.domain.Challenges;
+import wandogis.wandogi.domain.Users;
+
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.Date;
+
+@Getter
+@Setter
+public class ChallengeCreateDto {
+    @Id
+    private ObjectId id;
+    private String isbn;
+    private String title;
+    private String author;
+    private String photo;
+    private String description;
+    private String category;
+    private int page;
+    private int view;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private Date startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private Date endDate;
+
+    public Challenges toEntity() {
+        return Challenges.builder().id(id).title(title).author(author).photo(photo)
+                .description(description).category(category).page(page).view(view)
+                .startDate(startDate).endDate(endDate).build();
+    }
+}

--- a/src/main/java/wandogis/wandogi/service/DetailBookService.java
+++ b/src/main/java/wandogis/wandogi/service/DetailBookService.java
@@ -51,6 +51,8 @@ public class DetailBookService {
         result.put("img", data.get("cover"));
         result.put("author", data.get("author"));
         result.put("description", data.get("description"));
+        String[] categoryArr = data.get("categoryName").toString().split(">");
+        result.put("category", categoryArr[categoryArr.length-1]);
         result.put("pubDate", data.get("pubDate"));
         result.put("publisher", data.get("publisher"));
         JSONObject subInfo = (JSONObject) data.get("subInfo");


### PR DESCRIPTION
알라딘의 상품조회API로 정보를 받아올 때 책 카테고리(장르) 데이터를 추가했습니다.

챌린지 생성 시 데이터는 저장되지만 아직 참여유저와 진도율은 저장되지 않습니다.
-> 참여유저와 진도율을 다른 테이블로 빼려고 합니다.