### PR TITLE
[Feat] 챌린지 생성 시 Progress 테이블에 챌린지와 진행률 저장(User는 아직 저장X)

### DIFF
--- a/src/main/java/wandogis/wandogi/controller/ChallengeController.java
+++ b/src/main/java/wandogis/wandogi/controller/ChallengeController.java
@@ -1,11 +1,13 @@
 package wandogis.wandogi.controller;
 
 import lombok.AllArgsConstructor;
+import org.bson.types.ObjectId;
 import org.json.simple.parser.ParseException;
 import org.springframework.web.bind.annotation.*;
 import wandogis.wandogi.domain.Challenges;
 import wandogis.wandogi.dto.ChallengeCreateDto;
 import wandogis.wandogi.service.ChallengeService;
+import wandogis.wandogi.service.ProgressService;
 
 import java.util.List;
 
@@ -14,6 +16,7 @@ import java.util.List;
 @RequestMapping("challenges")
 public class ChallengeController {
     private ChallengeService challengeService;
+    private ProgressService progressService;
 
     /**
      * 진행 예정인 챌린지 목록 인기순
@@ -70,6 +73,7 @@ public class ChallengeController {
      */
     @PostMapping("/create")
     public void createChallenge(@RequestParam String isbn, @RequestBody ChallengeCreateDto challengeCreateDto) throws ParseException {
-        challengeService.saveChallenge(challengeCreateDto, isbn);
+        ObjectId challengeId = challengeService.saveChallenge(challengeCreateDto, isbn);
+        progressService.saveChallengeUserAndProgress(challengeId);
     }
 }

--- a/src/main/java/wandogis/wandogi/domain/Progress.java
+++ b/src/main/java/wandogis/wandogi/domain/Progress.java
@@ -2,11 +2,9 @@ package wandogis.wandogi.domain;
 
 import lombok.*;
 import org.bson.types.ObjectId;
+import org.hibernate.annotations.ColumnDefault;
 
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Getter
 @Setter
@@ -20,6 +18,7 @@ public class Progress {
     private Users user;
     @OneToOne
     private Challenges challenge;
+    @ColumnDefault("0.0")
     private Double progress;
 
     @Builder

--- a/src/main/java/wandogis/wandogi/dto/ProgressDto.java
+++ b/src/main/java/wandogis/wandogi/dto/ProgressDto.java
@@ -1,5 +1,6 @@
 package wandogis.wandogi.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
@@ -20,9 +21,15 @@ public class ProgressDto {
     private Users user;
     @OneToOne
     private Challenges challenge;
-    private Double progress;
+
+    @Builder.Default
+    private Double progress = 0.0;
 
     public Progress toEntity() {
         return Progress.builder().id(id).user(user).challenge(challenge).progress(progress).build();
+    }
+
+    public void setChallenge(Challenges challenge) {
+        this.challenge = challenge;
     }
 }

--- a/src/main/java/wandogis/wandogi/repository/ChallengeRepository.java
+++ b/src/main/java/wandogis/wandogi/repository/ChallengeRepository.java
@@ -6,9 +6,10 @@ import wandogis.wandogi.domain.Challenges;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ChallengeRepository extends MongoRepository<Challenges, ObjectId> {
-    public List<Challenges> findAll();
+    public Optional<Challenges> findById(ObjectId id);
 
     public List<Challenges> findAllByStartDateAfter(LocalDateTime today);  // 진행 예정 챌린지 목록
     public List<Challenges> findAllByEndDateAfterAndStartDateBefore(LocalDateTime today, LocalDateTime now);   // 진행 중인 챌린지 목록

--- a/src/main/java/wandogis/wandogi/repository/ProgressRepository.java
+++ b/src/main/java/wandogis/wandogi/repository/ProgressRepository.java
@@ -1,0 +1,8 @@
+package wandogis.wandogi.repository;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import wandogis.wandogi.domain.Progress;
+
+public interface ProgressRepository extends MongoRepository<Progress, ObjectId> {
+}

--- a/src/main/java/wandogis/wandogi/service/ChallengeService.java
+++ b/src/main/java/wandogis/wandogi/service/ChallengeService.java
@@ -1,5 +1,6 @@
 package wandogis.wandogi.service;
 
+import org.bson.types.ObjectId;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.ParseException;
 import org.springframework.stereotype.Service;
@@ -67,7 +68,7 @@ public class ChallengeService {
      * 챌린지 생성
      * isbn으로 해당 책에 대한 정보를 받아온 뒤, challenges 테이블에 해당 정보를 추가해서 함께 저장
      */
-    public void saveChallenge(ChallengeCreateDto challengeCreateDto, String isbn) throws ParseException {
+    public ObjectId saveChallenge(ChallengeCreateDto challengeCreateDto, String isbn) throws ParseException {
         JSONObject book = detailBookService.getBookDetailInfoFromAladin(isbn);
         challengeCreateDto.setIsbn((String) book.get("isbn"));
         challengeCreateDto.setTitle((String) book.get("title"));
@@ -78,6 +79,7 @@ public class ChallengeService {
         challengeCreateDto.setPage(Integer.parseInt(String.valueOf(book.get("page"))));
         Challenges challenge = challengeCreateDto.toEntity();
         challengeRepository.save(challenge);
+        return challenge.getId();
     }
 }
 

--- a/src/main/java/wandogis/wandogi/service/ProgressService.java
+++ b/src/main/java/wandogis/wandogi/service/ProgressService.java
@@ -1,0 +1,35 @@
+package wandogis.wandogi.service;
+
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import wandogis.wandogi.domain.Challenges;
+import wandogis.wandogi.domain.Progress;
+import wandogis.wandogi.dto.ProgressDto;
+import wandogis.wandogi.repository.ChallengeRepository;
+import wandogis.wandogi.repository.ProgressRepository;
+
+import java.util.Optional;
+
+@Service
+public class ProgressService {
+    private final ProgressRepository progressRepository;
+    private final ChallengeRepository challengeRepository;
+
+
+    public ProgressService(ProgressRepository progressRepository, ChallengeRepository challengeRepository) {
+        this.progressRepository = progressRepository;
+        this.challengeRepository = challengeRepository;
+    }
+
+    /**
+     * 챌린지에 유저가 참여했을 때
+     * 유저 추가
+     */
+    public void saveChallengeUserAndProgress(ObjectId challengeId) {
+        ProgressDto progressDto = new ProgressDto();
+        Challenges challenge = challengeRepository.findById(challengeId).get();
+        progressDto.setChallenge(challenge);
+        Progress progress = progressDto.toEntity();
+        progressRepository.save(progress);
+    }
+}


### PR DESCRIPTION
챌린지 생성 시 챌린지 테이블에 정보를 저장하는 것에 추가하여
챌린지와 챌린지에 참여한 유저(여기서는 챌린지를 생성한 유저), 진행률(생성 직후에는 0.0으로 초기화)을 저장하는 코드를 작성했습니다.

아직 유저 로그인 부분을 구현하지 않아서 유저는 저장되지 않습니다.