### PR TITLE
[Fix] 챌린지 인기순을 참여인원순으로 변경

### DIFF
--- a/src/main/java/wandogis/wandogi/controller/ChallengeController.java
+++ b/src/main/java/wandogis/wandogi/controller/ChallengeController.java
@@ -21,7 +21,7 @@ public class ChallengeController {
     /**
      * 진행 예정인 챌린지 목록 인기순
      */
-    @GetMapping("/list/expected-view")
+    @GetMapping("/list/expected-people")
     public Object expectedViewList() {
         List<Challenges> expectedList = challengeService.getChallengeListByStartDate();
         List<Challenges> viewList = challengeService.getChallengeListByPeople(expectedList);
@@ -41,7 +41,7 @@ public class ChallengeController {
     /**
      * 진행 중인 챌린지 인기순
      */
-    @GetMapping("/list/going-view")
+    @GetMapping("/list/going-people")
     public Object goingViewList() {
         List<Challenges> goingList = challengeService.getChallengeListByEndDateAndStartDate();
         List<Challenges> viewList = challengeService.getChallengeListByPeople(goingList);

--- a/src/main/java/wandogis/wandogi/domain/Challenges.java
+++ b/src/main/java/wandogis/wandogi/domain/Challenges.java
@@ -33,15 +33,11 @@ public class Challenges {
     private Date startDate;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date endDate;
-    @OneToMany(mappedBy = "challenges")
-    private ArrayList<Users> people = new ArrayList<>();   // 챌린지 참여한 사람들 Users 배열
-    private ArrayList<Double> progress;    // 진도율(people 배열과 동일한 index를 가진 값이 그 유저의 진도율)
-    @Column(nullable = true)
     private Boolean success;    // 챌린지 성공 여부(실패: False, 성공: True)
 
     @Builder
-    public Challenges(ObjectId id, String isbn, String title, String author, String photo, String description, String category, int page,
-                      int view, Date startDate, Date endDate, ArrayList<Users> people, ArrayList<Double> progress, Boolean success) {
+    public Challenges(ObjectId id, String isbn, String title, String author, String photo, String description,
+                      String category, int page, int view, Date startDate, Date endDate, Boolean success) {
         this.id = id;
         this.isbn = isbn;
         this.title = title;

--- a/src/main/java/wandogis/wandogi/dto/ChallengeCreateDto.java
+++ b/src/main/java/wandogis/wandogi/dto/ChallengeCreateDto.java
@@ -1,6 +1,7 @@
 package wandogis.wandogi.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import org.bson.types.ObjectId;
@@ -24,7 +25,8 @@ public class ChallengeCreateDto {
     private String description;
     private String category;
     private int page;
-    private int view;
+    @Builder.Default
+    private int view = 0;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date startDate;
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/wandogis/wandogi/repository/ProgressRepository.java
+++ b/src/main/java/wandogis/wandogi/repository/ProgressRepository.java
@@ -2,7 +2,11 @@ package wandogis.wandogi.repository;
 
 import org.bson.types.ObjectId;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import wandogis.wandogi.domain.Challenges;
 import wandogis.wandogi.domain.Progress;
 
+import java.util.List;
+
 public interface ProgressRepository extends MongoRepository<Progress, ObjectId> {
+    public List<Progress> findAllByChallenge(Challenges challenge);
 }


### PR DESCRIPTION
챌린지 인기순을 참여인원순으로 변경했습니다.
Progress테이블에 해당 챌린지인 행의 개수가 참여인원 수