### PR TITLE
[Fix] Users domain 수정 - field 추가 및 변경

### DIFF
--- a/src/main/java/wandogis/wandogi/domain/Users.java
+++ b/src/main/java/wandogis/wandogi/domain/Users.java
@@ -1,20 +1,31 @@
 package wandogis.wandogi.domain;//테이블정보
 
 import lombok.Data;
+import org.bson.types.ObjectId;
+
+import javax.persistence.*;
+import java.util.List;
 
 @Data
+@Entity
 public class Users {
-    private String loginid;
-    private String password;
-    private String name;
-    private String photo;
-    private String genre;
-    private String age;
-    private String challenge;
-
-    @Override
-    public String toString() {
-        return "name is " + name;
-    }
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private ObjectId id;        // DB 자동 생성
+    @Column(nullable = false)
+    private String email;       // 가입되어있는 회원인지 확인함
+    @Column(nullable = false)
+    private String nickname;    // 사용자 닉네임
+    @Column(nullable = false)
+    private int socialType;     // 1: Naver, 2: Kakao
+    @Column(nullable = false)
+    private String photo;       // 사용자 프로필 이미지
+    private String genre;       // 도서 추천 때 선택 입력(선호하는 장르)
+    private int age;            // 도서 추천 때 선택 입력
+    private String gender;      // 도서 추천 때 선택 입력
+    private int ranking;        // 완료한 챌린지 개수에 따른 오늘의 순위
+    private int numOfChallenge; // 완료한 챌린지 개수
+    private List<ObjectId> books;      // 유저가 선호하는 책(Books와 One-to-Many)
+    private List<ObjectId> challenges; // 유저가 진행한 챌린지(Challenges와 Many-to-Many)
+    private List<ObjectId> calendars;  // 유저 달력(날짜)(Calendars와 One-to-Many)
 }
-


### PR DESCRIPTION
Users 도메인을 수정했습니다.
네이버로그인을 우선 구현할 계획이며, 우선 그에 맞는 필드를 생성했습니다.
추가로 마이페이지 등에서 사용하기 위해 유저별로 저장해줘야 한다고 생각되는 데이터 필드를 추가했습니다.
books는 유저가 선호하는 책 데이터이며, Books 도메인의 데이터 id를 리스트로 저장하게 했습니다.
challenges는 챌린지 데이터, calendars는 달력에 유저가 읽은 책을 표시하는 데이터 정보입니다. 저장 방식은 books와 같습니다.

네이버 로그인을 구현하면서 또 변경될 수 있습니다.